### PR TITLE
Add dry run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: Remove CoPilot from Inactive Users
 description: I check all Org CoPilot users and remove them if they are inactive for too long
 inputs:
+  dry-run:
+    description: Do not actually remove users
+    default: false
   github-org:
     description: Name of the GitHub Organization
     required: true
@@ -19,8 +22,9 @@ runs:
       run: |
         
         ###
-        ### Set vars
+        ### Set inputs
         ###
+        dry_run="${{ inputs.dry-run }}"
         max_days_inactive="${{ inputs.max-days-inactive }}"
         gh_org="${{ inputs.github-org }}"
         GITHUB_TOKEN="${{ inputs.github-pat }}"
@@ -72,6 +76,10 @@ runs:
 
         # Remove user from copilot
         remove_user_from_copilot() {
+          if [[ $dry_run == "true" ]]; then
+            echo "🧪 Would remove $copilot_user from CoPilot"
+            return 0
+          fi
           
           REMOVE_USER_FROM_COPILOT=$(curl -sL \
             -X DELETE \
@@ -95,6 +103,10 @@ runs:
         ###
         ### Fetch users to iterate over
         ###
+
+        if [[ $dry_run == "true" ]]; then
+          echo "🧪 Dry run is enabled.  Users won't be removed"
+        fi
 
         # Get count of all seats
         copilot_seats_total_count=$(curl -s \

--- a/action.yml
+++ b/action.yml
@@ -251,7 +251,7 @@ runs:
 
         for user in ${removed_users[@]}; do
           echo "  $user"
-        done | sort
+        done | sort -f
 
         if [[ ${#removed_users[@]} -eq 0 ]]; then
           echo "  ** No users apply **"
@@ -263,7 +263,7 @@ runs:
           echo "The following users could not be removed (see above for details):"
           for user in ${removal_failures[@]}; do
             echo "  $user"
-          done | sort
+          done | sort -f
         fi
 
         exit 0

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         # Remove user from copilot
         remove_user_from_copilot() {
           if [[ $dry_run == "true" ]]; then
-            echo "🧪 Would remove $copilot_user from CoPilot"
+            echo "🧪 Would remove $copilot_user from Copilot"
             removed_users+=($copilot_user)
             return 0
           fi
@@ -244,9 +244,9 @@ runs:
         echo
 
         if [[ $dry_run == "true" ]]; then
-          echo "The following users would have been removed from CoPilot:"
+          echo "The following users would have been removed from Copilot:"
         else
-          echo "The following users were removed from CoPilot:"
+          echo "The following users were removed from Copilot:"
         fi
 
         for user in ${removed_users[@]}; do

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,13 @@ runs:
 
 
         ###
+        ### Reporting
+        ###
+        removed_users=()
+        removal_failures=()
+        
+        
+        ###
         ### Functions
         ###
 
@@ -78,6 +85,7 @@ runs:
         remove_user_from_copilot() {
           if [[ $dry_run == "true" ]]; then
             echo "🧪 Would remove $copilot_user from CoPilot"
+            removed_users+=($copilot_user)
             return 0
           fi
           
@@ -92,9 +100,11 @@ runs:
             # If response contains json key seats_cancelled, it worked
             if [[ $REMOVE_USER_FROM_COPILOT == *"seats_cancelled"* ]]; then
               echo "✅ User $copilot_user removed from CoPilot"
+              removed_users+=($copilot_user)
             else
               echo "❌ Failed to remove user $copilot_user from CoPilot, please investigate:"
               echo "$REMOVE_USER_FROM_COPILOT"
+              removal_failures+=($copilot_user)
             fi
 
         }
@@ -231,6 +241,31 @@ runs:
         echo "################"
         echo "Done!"
         echo "################"
+        echo
+
+        if [[ $dry_run == "true" ]]; then
+          echo "The following users would have been removed from CoPilot:"
+        else
+          echo "The following users were removed from CoPilot:"
+        fi
+
+        for user in ${removed_users[@]}; do
+          echo "  $user"
+        done | sort
+
+        if [[ ${#removed_users[@]} -eq 0 ]]; then
+          echo "  ** No users apply **"
+        fi
+
+        echo
+
+        if [[ ${#removal_failures[@]} -gt 0 ]]; then
+          echo "The following users could not be removed (see above for details):"
+          for user in ${removal_failures[@]}; do
+            echo "  $user"
+          done | sort
+        fi
+
         exit 0
 
       shell: bash

--- a/disable_inactive.sh
+++ b/disable_inactive.sh
@@ -3,6 +3,7 @@
 ###
 ### Set inputs
 ###
+dry_run="${{ inputs.dry-run }}"
 max_days_inactive="${{ inputs.max-days-inactive }}"
 gh_org="${{ inputs.github-org }}"
 GITHUB_TOKEN="${{ inputs.github-pat }}"
@@ -54,6 +55,10 @@ hold_until_rate_limit_success() {
 
 # Remove user from copilot
 remove_user_from_copilot() {
+  if [[ $dry_run == "true" ]]; then
+    echo "🧪 Would remove $copilot_user from CoPilot"
+    return 0
+  fi
   
   REMOVE_USER_FROM_COPILOT=$(curl -sL \
     -X DELETE \
@@ -77,6 +82,10 @@ remove_user_from_copilot() {
 ###
 ### Fetch users to iterate over
 ###
+
+if [[ $dry_run == "true" ]]; then
+  echo "🧪 Dry run is enabled.  Users won't be removed"
+fi
 
 # Get count of all seats
 copilot_seats_total_count=$(curl -s \
@@ -157,7 +166,7 @@ while IFS=$'\n' read -r copilot_user; do
   last_editor=$(echo "$user_data" | jq -r '.last_activity_editor')
   echo "Last editor: $last_editor"
 
-   # Get the last active date of the user
+  # Get the last active date of the user
   last_active_date=$(echo "$user_data" | jq -r '.last_activity_at')
   echo "Last activity date at: $last_active_date"
 

--- a/disable_inactive.sh
+++ b/disable_inactive.sh
@@ -63,7 +63,7 @@ hold_until_rate_limit_success() {
 # Remove user from copilot
 remove_user_from_copilot() {
   if [[ $dry_run == "true" ]]; then
-    echo "🧪 Would remove $copilot_user from CoPilot"
+    echo "🧪 Would remove $copilot_user from Copilot"
     removed_users+=($copilot_user)
     return 0
   fi
@@ -223,9 +223,9 @@ echo "################"
 echo
 
 if [[ $dry_run == "true" ]]; then
-  echo "The following users would have been removed from CoPilot:"
+  echo "The following users would have been removed from Copilot:"
 else
-  echo "The following users were removed from CoPilot:"
+  echo "The following users were removed from Copilot:"
 fi
 
 for user in ${removed_users[@]}; do

--- a/disable_inactive.sh
+++ b/disable_inactive.sh
@@ -18,6 +18,13 @@ date_one_month_ago=$(($current_date_in_epoc - $number_of_seconds_in_a_month))
 
 
 ###
+### Reporting
+###
+removed_users=()
+removal_failures=()
+
+
+###
 ### Functions
 ###
 
@@ -57,6 +64,7 @@ hold_until_rate_limit_success() {
 remove_user_from_copilot() {
   if [[ $dry_run == "true" ]]; then
     echo "🧪 Would remove $copilot_user from CoPilot"
+    removed_users+=($copilot_user)
     return 0
   fi
   
@@ -71,9 +79,11 @@ remove_user_from_copilot() {
     # If response contains json key seats_cancelled, it worked
     if [[ $REMOVE_USER_FROM_COPILOT == *"seats_cancelled"* ]]; then
       echo "✅ User $copilot_user removed from CoPilot"
+      removed_users+=($copilot_user)
     else
       echo "❌ Failed to remove user $copilot_user from CoPilot, please investigate:"
       echo "$REMOVE_USER_FROM_COPILOT"
+      removal_failures+=($copilot_user)
     fi
 
 }
@@ -210,4 +220,29 @@ echo ""
 echo "################"
 echo "Done!"
 echo "################"
+echo
+
+if [[ $dry_run == "true" ]]; then
+  echo "The following users would have been removed from CoPilot:"
+else
+  echo "The following users were removed from CoPilot:"
+fi
+
+for user in ${removed_users[@]}; do
+  echo "  $user"
+done | sort
+
+if [[ ${#removed_users[@]} -eq 0 ]]; then
+  echo "  ** No users apply **"
+fi
+
+echo
+
+if [[ ${#removal_failures[@]} -gt 0 ]]; then
+  echo "The following users could not be removed (see above for details):"
+  for user in ${removal_failures[@]}; do
+    echo "  $user"
+  done | sort
+fi
+
 exit 0

--- a/disable_inactive.sh
+++ b/disable_inactive.sh
@@ -230,7 +230,7 @@ fi
 
 for user in ${removed_users[@]}; do
   echo "  $user"
-done | sort
+done | sort -f
 
 if [[ ${#removed_users[@]} -eq 0 ]]; then
   echo "  ** No users apply **"
@@ -242,7 +242,7 @@ if [[ ${#removal_failures[@]} -gt 0 ]]; then
   echo "The following users could not be removed (see above for details):"
   for user in ${removal_failures[@]}; do
     echo "  $user"
-  done | sort
+  done | sort -f
 fi
 
 exit 0


### PR DESCRIPTION
This adds the option for a user to perform a dry run of cleaning up Copilot licenses.  It also prints out a report at the end of a run with which users it (would have) removed, as well as any failures.