### PR TITLE
Move rate limiting check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,10 @@ runs:
             removed_users+=($copilot_user)
             return 0
           fi
-          
+
+          # Check rate limit blockers, hold if token bucket too low
+          hold_until_rate_limit_success
+
           REMOVE_USER_FROM_COPILOT=$(curl -sL \
             -X DELETE \
             -H "Accept: application/vnd.github+json" \
@@ -161,9 +164,6 @@ runs:
           
           # Print divider
           echo "****************************************"
-
-          # Check rate limit blockers, hold if token bucket too low
-          hold_until_rate_limit_success
 
           # Print the user we're looking at
           echo "🔍 Looking into $copilot_user"


### PR DESCRIPTION
Noticed that the rate limiting check is in the middle of a loop that does not interact with Github APIs.

So, it is making the `gh api -i "repos/$gh_org" 2>&1 | grep -Ei '^X-Ratelimit-Remaining'` every user, regardless of it we will need to interact with the Github API for that user. 

By moving it, we can skip that check for all users who do use Copilot or were recently added.